### PR TITLE
Bugfix: circumvent MemoryError that occurs when the number of samples…

### DIFF
--- a/visbrain/io/rw_hypno.py
+++ b/visbrain/io/rw_hypno.py
@@ -73,8 +73,13 @@ def hypno_time_to_sample(df, npts):
         time = np.arange(npts) * time_idx[-1] / (npts - 1)
     sf_hyp = 1. / (time[1] - time[0])
     # Find closest time index :
-    index = np.abs(time.reshape(-1, 1) - time_idx.reshape(1, -1))
-    index = np.r_[0, index.argmin(0) + 1]
+    try:
+        index = np.abs(time.reshape(-1, 1) - time_idx.reshape(1, -1))
+        index = np.r_[0, index.argmin(0) + 1]
+    except MemoryError:
+        index = np.zeros((len(time_idx)+1), dtype=int)
+        for ii, t in enumerate(time_idx):
+            index[ii+1] = np.argmin(np.abs(time-t)) + 1
     # Fill the hypnogram :
     hypno = np.zeros((len(time),), dtype=int)
     for k in range(len(index) - 1):


### PR DESCRIPTION
… (npts) is very large.

When trying to import hypnograms in the stage-duration format, I am running out of memory on a 16 GB RAM machine as the (transiently) created array `index` in `hypno_time_to_sample` becomes extremely large. As `index` is collapsed in one dimension right in the next line, I just substituted the relevant lines with a for loop that computes the collapsed array in one go. This is probably even faster than the version with (the arguably more elegant) broadcasting as the allocation for the broadcasted array will eat a lot of time; however, I haven't timed it (just noticed a faster startup of `Sleep.show()` even for small files).  