### PR TITLE
Don't clean raw channel labels and fix/refactor rereferencing

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -19,12 +19,15 @@ New features
 Improvements
 ~~~~~~~~~~~~
 
+* Update automatic detection of non-eeg channels used during re-referencing (`PR63 <https://github.com/EtienneCmb/visbrain/pull/63>`_)
+* "Clean" channel labels only during bipolar re-referencing in Sleep (`PR63 <https://github.com/EtienneCmb/visbrain/pull/63>`_)
 * Protect Sleep from MemoryError for large sleep files (`PR37 <https://github.com/EtienneCmb/visbrain/pull/37>`_)
 * Improve spectrogram in case of non finite values (`PR39 <https://github.com/EtienneCmb/visbrain/pull/39>`_)
 * Fix path to the url file for pyenv (`PR41 <https://github.com/EtienneCmb/visbrain/pull/41>`_)
 
 Bug fixes
 ~~~~~~~~~
+* Fix use of wrong channel during re-referencing to specific channel (`PR63 <https://github.com/EtienneCmb/visbrain/pull/63>`_)
 * Fix `allow_pickle`
 * Fix imresize from the scipy package
 

--- a/visbrain/gui/sleep/interface/ui_elements/ui_tools.py
+++ b/visbrain/gui/sleep/interface/ui_elements/ui_tools.py
@@ -78,7 +78,7 @@ class UiTools(object):
     def _fcn_ref_apply(self):
         """Apply re-referencing."""
         # By default, ingore non-eeg channel :
-        to_ignore = self._noneeg
+        to_ignore = list(self._noneeg)
         if self._ToolsRefIgn.isChecked():
             for num, k in enumerate(self._reChecks):
                 # Get the position of this channel :
@@ -90,11 +90,14 @@ class UiTools(object):
         idx = int(self._ToolsRefMeth.currentIndex())
         # Single channel :
         if idx == 0:  # Single channel
-            # Get selected channel :
-            idchan = idx = self._ToolsRefLst.currentIndex()
+            # Get selected channel for re-referencing:
+            # index of ref amongst candidate channels (~noneeg)
+            idchan_eeg = idx = self._ToolsRefLst.currentIndex()
+            # overall index of reference channel
+            idchan_all = np.where(~self._noneeg)[0][idchan_eeg]
             # Re-referencing :
             self._data, self._channels, consider = rereferencing(
-                self._data, self._channels, idchan,
+                self._data, self._channels, idchan_all,
                 to_ignore)
             self._chanChecks[idx].setChecked(False)
         elif idx == 1:  # Common average

--- a/visbrain/io/read_sleep.py
+++ b/visbrain/io/read_sleep.py
@@ -148,20 +148,6 @@ class ReadSleepData(object):
             warn("The number of channels must be " + str(nchan) + ". Default "
                  "channel names will be used instead.")
             channels = ['chan' + str(k) for k in range(nchan)]
-        # Clean channel names :
-        patterns = ['eeg', 'EEG', 'ref']
-        chanc = []
-        for c in channels:
-            # Remove informations after . :
-            c = c.split('.')[0]
-            c = c.split('-')[0]
-            # Exclude patterns :
-            for i in patterns:
-                c = c.replace(i, '')
-            # Remove space :
-            c = c.replace(' ', '')
-            c = c.strip()
-            chanc.append(c)
 
         # ---------- STAGE ORDER ----------
         # href checking :

--- a/visbrain/io/read_sleep.py
+++ b/visbrain/io/read_sleep.py
@@ -203,7 +203,7 @@ class ReadSleepData(object):
         self._data = vispy_array(data)
         self._hypno = vispy_array(hypno)
         self._time = vispy_array(time)
-        self._channels = chanc
+        self._channels = channels
         self._href = href
         self._hconv = conv
         PROFILER("Check data", level=1)

--- a/visbrain/utils/physio.py
+++ b/visbrain/utils/physio.py
@@ -26,17 +26,19 @@ def find_non_eeg(channels, pattern=['eog', 'emg', 'ecg', 'abd']):
 
     Returns
     -------
-    iseeg : array_like
-        NumPy vector of boolean values.
+    noneeg : array_like
+        NumPy vector of boolean values. True if any of the strings in `pattern`
+        is found in the channel label string
     """
     # Set channels in lower case :
     channels = np.char.lower(np.asarray(channels))
     # Pre-allocation :
-    iseeg = np.zeros((len(channels),), dtype=bool)
+    noneeg = np.zeros((len(channels),), dtype=bool)
     # Search patterns :
     for k in pattern:
-        iseeg += np.invert(np.char.find(channels, k).astype(bool))
-    return iseeg
+        # Add to non-eeg if we find the pattern anywhere in the channel string
+        noneeg += np.char.find(channels, k) >= 0
+    return noneeg
 
 
 ###############################################################################

--- a/visbrain/utils/physio.py
+++ b/visbrain/utils/physio.py
@@ -93,8 +93,18 @@ def rereferencing(data, chans, reference, to_ignore=None):
     return data, chan, consider
 
 
-def bipolarization(data, chans, to_ignore=None, sep='.'):
+def bipolarization(data, chans, to_ignore=None):
     """Bipolarize data.
+
+    Channel labels are cleaned and for each channel a "name" and "number" are
+    extracted using the following steps:
+        1- Remove spaces and remove everything after "-" or "." in channel name
+        2- Set as channel "number" the last series of digits in the label
+        3- Set as channel "name" everything in the cleaned label preceding the
+            channel number
+    For example the name and number of channel "EEG1,2-A1" are "EEG1," and "2".
+    Bipolarization is done by substracting channels with the same name for
+    successive numbers.
 
     Parameters
     ----------
@@ -104,10 +114,6 @@ def bipolarization(data, chans, to_ignore=None, sep='.'):
         List of channel names of length nchan.
     to_ignore : list | None
         List of channels to ignore in the bipolarization.
-    sep : string | '.'
-        Separator to simplify electrode names by removing undesired name
-        after the sep. For example, if channel = ['h1.025', 'h2.578']
-        and sep='.', the final name will be 'h2-h1'.
 
     Returns
     -------
@@ -125,17 +131,25 @@ def bipolarization(data, chans, to_ignore=None, sep='.'):
 
     # Preprocess channel names by separating channel names / number:
     chnames, chnums = [], []
-    for num, k in enumerate(chans):
-        # Remove spaces and separation :
-        chans[num] = k.strip().replace(' ', '').split(sep)[0]
+    for num, c in enumerate(chans):
+        # Remove spaces and everything after "." and "-"
+        c = c.split('.')[0]
+        c = c.split('-')[0]
+        c = c.strip().replace(' ', '')
         # Get only the name / number :
-        if findall(r'\d+', k):
-            number = findall(r'\d+', k)[0]
-            chnums.append(number)
-            chnames.append(k.split(number)[0])
+        if findall(r'\d+', c):
+            # Last series of digits in label are the channel "number"
+            number = findall(r'\d+', c)[-1]
+            # Everything before the channel number is the channel "name"
+            # (Everything after channel number disappears)
+            name = number.join(c.split(number)[0:-1])
         else:
-            chnums.append('')
-            chnames.append(k)
+            number = ''
+            name = c
+        chnums.append(number)
+        chnames.append(name)
+        # Save the cleaned channel label
+        chans[num] = name + number
 
     # Find if some channels have to be ignored :
     if to_ignore is None:

--- a/visbrain/utils/physio.py
+++ b/visbrain/utils/physio.py
@@ -14,14 +14,14 @@ __all__ = ('find_non_eeg', 'rereferencing', 'bipolarization', 'commonaverage',
 logger = logging.getLogger('visbrain')
 
 
-def find_non_eeg(channels, pattern=['eog', 'emg', 'ecg', 'abd']):
+def find_non_eeg(channels, pattern=['eog', 'emg', 'ecg', 'abd', 'lfp']):
     """Find non-EEG channels.
 
     Parameters
     ----------
     channels : list
         List of channel names.
-    pattern : list | ['eog', 'emg', 'ecg', 'abd']
+    pattern : list | ['eog', 'emg', 'ecg', 'abd', 'lfp']
         List of patterns for non-EEG channels.
 
     Returns


### PR DESCRIPTION
Use channel labels as provided by user or loaded from data, without "cleaning", in ReadSleep