### PR TITLE
Fix MNE bdf/gdf EEG file imports

### DIFF
--- a/visbrain/io/mneio.py
+++ b/visbrain/io/mneio.py
@@ -47,9 +47,13 @@ def mne_switch(file, ext, downsample, preload=True, **kwargs):
         preload = 'temp.dat'
     kwargs['preload'] = preload
 
-    if ext.lower() in ['.edf', '.bdf', '.gdf']:  # EDF / BDF / GDF
+    if ext.lower() in '.edf':   # EDF
         raw = io.read_raw_edf(path, **kwargs)
-    elif ext.lower == '.set':   # EEGLAB
+    elif ext.lower() == '.bdf':   # BDF
+        raw = io.read_raw_bdf(path, **kwargs)
+    elif ext.lower() == '.gdf':   # GDF
+        raw = io.read_raw_gdf(path, **kwargs)
+    elif ext.lower() == '.set':   # EEGLAB
         raw = io.read_raw_eeglab(path, **kwargs)
     elif ext.lower() in ['.egi', '.mff']:  # EGI / MFF
         raw = io.read_raw_egi(path, **kwargs)


### PR DESCRIPTION
Importing .bdf and .gdf currently fails (NME 0.21.1) because those filetypes have their own importers.
This change will make them work again in the Sleep GUI when chosen on open file.