### PR TITLE
Set new hypnogram format as default

### DIFF
--- a/visbrain/gui/sleep/interface/ui_elements/ui_menu.py
+++ b/visbrain/gui/sleep/interface/ui_elements/ui_menu.py
@@ -105,9 +105,11 @@ class UiMenu(HelpMenu):
                    "Click 'Yes' to use the new format and 'No' to use the old "
                    "format. For more information, visit the doc at "
                    "visbrain.org/sleep")
-            reply = QtWidgets.QMessageBox.question(self, 'Message', msg,
-                                                   QtWidgets.QMessageBox.Yes,
-                                                   QtWidgets.QMessageBox.No)
+            reply = QtWidgets.QMessageBox.question(
+                self, 'Message', msg,
+                buttons=(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No),
+                defaultButton=QtWidgets.QMessageBox.Yes,
+            )
         if reply == QtWidgets.QMessageBox.No:  # v1 = sample
             dialog_ext = "Text file (*.txt);;Elan file (*.hyp)"
             version = 'sample'


### PR DESCRIPTION
There is currently an inconsistency when saving hypnogram data:

the default button of the question box asking whether or not to use the new format is "No [use old format]", while the question text suggests the default should be "Yes": 
```
`Since release 0.4, hypnogram are exported using stage "
"duration rather than point-per-second. This new format "
"avoids potential errors caused by downsampling and "
"confusion in the values assigned to each sleep stage. \n\n"
"Click 'Yes' to use the new format and 'No' to use the old "
"format. For more information, visit the doc at 
```

This PR simply changes the default button to "Yes [use new format]"